### PR TITLE
chore: upgrade to vault-1.9.0

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Create KIND cluster with Registry
         # uses: helm/kind-action@v1.2.0
         uses: container-tools/kind-action@v1
-        if: steps.list-changed.outputs.changed == 'true'
+        # if: steps.list-changed.outputs.changed == 'true'
 
       - name: Build Docker Image for local testing
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG KUBECTL_VERSION="stable"
 
 # Add more dependencies
 RUN apk add  --no-cache jq bash curl openssl \
-    && [[ KUBECTL_VERSION -eq "stable" ]] && KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) \
+    && [[ $KUBECTL_VERSION = "stable" ]] && KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) \
     && curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM vault:1.6.7
+FROM vault:1.9.0
 ARG KUBECTL_VERSION="stable"
 
 # Add more dependencies
 RUN apk add  --no-cache jq bash curl openssl \
-    && curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" \
+    && [[ KUBECTL_VERSION -eq "stable" ]] && KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) \
+    && curl -LO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl
 

--- a/charts/vault-gcr-secrets/Chart.yaml
+++ b/charts/vault-gcr-secrets/Chart.yaml
@@ -5,5 +5,5 @@ home: https://github.com/TJM/vault-gcr-secrets
 # icon: https://raw.githubusercontent.com/TJM/vault-gcr-secrets/master/assets/logo.png
 maintainers:
   - name: TJM  # Tommy McNeely
-version: 0.2.0
-appVersion: 0.2.0
+version: 0.3.0
+appVersion: 0.3.0

--- a/charts/vault-gcr-secrets/values.yaml
+++ b/charts/vault-gcr-secrets/values.yaml
@@ -5,7 +5,7 @@ deploymentStrategy: {}
 
 image:
   repository: quay.io/tommydavita/vault-gcr-secrets
-  tag: v0.1.5
+  tag: v0.3.0
   pullPolicy: IfNotPresent
   volumeMounts: []
     # - name: ca


### PR DESCRIPTION
This upgrades Vault to 1.9.0, and fixes the unused KUBECTL_VERSION arg.